### PR TITLE
added missing address info on iOS to card nonce

### DIFF
--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -121,8 +121,6 @@ RCT_EXPORT_METHOD(payPalRequestBillingAgreement:(NSString *)amount
         }
     } else if ( error != nil ) {
         args = @[error.description, [NSNull null]];
-    } else { // per braintree docs, if both error and token are nil, user cancelled
-        args = @[@"USER_CANCELLATION", [NSNull null]];
     }
 
     callback(args);
@@ -133,11 +131,9 @@ RCT_EXPORT_METHOD(getCardNonce:(NSDictionary *)params
 {
     NSMutableDictionary *parameters = [params mutableCopy];
     BTCardClient *cardClient = [[BTCardClient alloc] initWithAPIClient:self.braintreeClient];
-    BTCard *card = [[BTCard alloc] initWithNumber:parameters[@"number"]
-                                  expirationMonth:parameters[@"expirationMonth"]
-                                   expirationYear:parameters[@"expirationYear"]
-                                              cvv:parameters[@"cvv"]];
-    card.shouldValidate = NO;
+
+    BTCard *card = [self createCardWithParameters:parameters];
+
     [cardClient tokenizeCard:card
                   completion:^(BTCardNonce *tokenizedCard, NSError *error) {
         if (error == nil) {
@@ -163,6 +159,52 @@ RCT_EXPORT_METHOD(getCardNonce:(NSDictionary *)params
         }
         callback(args);
     }];
+}
+
+- (BTCard*)createCardWithParameters:(NSMutableDictionary*)parameters
+{
+    BTCard *card = [[BTCard alloc] initWithNumber:parameters[@"number"]
+                                  expirationMonth:parameters[@"expirationMonth"]
+                                   expirationYear:parameters[@"expirationYear"]
+                                              cvv:parameters[@"cvv"]];
+
+    card.postalCode = parameters[@"postalCode"];
+
+    if (parameters[@"cardholderName"] != nil) {
+        card.cardholderName = parameters[@"cardholderName"];
+    }
+
+    if (parameters[@"firstName"] != nil) {
+        card.firstName = parameters[@"firstName"];
+    }
+
+    if (parameters[@"lastName"] != nil) {
+        card.lastName = parameters[@"lastName"];
+    }
+
+    if (parameters[@"streetAddress"] != nil) {
+        card.streetAddress = parameters[@"streetAddress"];
+    }
+
+    if (parameters[@"extendedAddress"] != nil) {
+        card.extendedAddress = parameters[@"extendedAddress"];
+    }
+
+    if (parameters[@"locality"] != nil) {
+        card.locality = parameters[@"locality"];
+    }
+
+    if (parameters[@"region"] != nil) {
+        card.region = parameters[@"region"];
+    }
+
+    if (parameters[@"countryCode"] != nil) {
+        // We always send down ISO 3-letter codes since android uses those too
+        card.countryCodeAlpha3 = parameters[@"countryCode"];
+    }
+
+    card.shouldValidate = NO;
+    return card;
 }
 
 RCT_EXPORT_METHOD(getDeviceData:(NSDictionary *)options

--- a/ios/RCTBraintree/RCTBraintree.m
+++ b/ios/RCTBraintree/RCTBraintree.m
@@ -121,6 +121,8 @@ RCT_EXPORT_METHOD(payPalRequestBillingAgreement:(NSString *)amount
         }
     } else if ( error != nil ) {
         args = @[error.description, [NSNull null]];
+    } else { // per braintree docs, if both error and token are nil, user cancelled
+        args = @[@"USER_CANCELLATION", [NSNull null]];
     }
 
     callback(args);


### PR DESCRIPTION
We need to manually add all the fields like we do on Android.
Tested via making this change locally in my Xcode project and submitting (and succeeding) on a address required and address not-required deposit.